### PR TITLE
Added download button to download the formated data as a csvfile

### DIFF
--- a/src/components/OutputPreview.tsx
+++ b/src/components/OutputPreview.tsx
@@ -17,6 +17,10 @@ interface Props {
 	columnQueries: TransformManifest;
 	filteredJson: FilteredJson;
 }
+const MimeType: Record<OutputFormat, string> = {
+	[OutputFormat.CSV]: 'text/csv',
+	[OutputFormat.TSV]: 'text/tab-seprated-values' 
+}
 
 export const OutputPreview = ({ columnQueries, filteredJson }: Props) => {
 	const [format, setFormat] = useState<OutputFormat>(OutputFormat.CSV);
@@ -52,11 +56,9 @@ export const OutputPreview = ({ columnQueries, filteredJson }: Props) => {
 
 	const handleDownload = useCallback(()=>{		
 		const transformedText = getTransformedAsText.current();
-		let type = OutputFormat.CSV;
-		if(format === OutputFormat.TSV)
-			type = OutputFormat.TSV
-		let data = new Blob([transformedText], {type:`text/${type}`});
-		let url = window.URL.createObjectURL(data);
+		const type = MimeType[format];
+		const data = new Blob([transformedText],{type});
+		const url = window.URL.createObjectURL(data);
 		setFileLink(url);
 	}, [format])
 
@@ -83,7 +85,7 @@ export const OutputPreview = ({ columnQueries, filteredJson }: Props) => {
 					<button className="border py-1 px-2" onClick={handleCopyEvent}>
 						Copy as {format.toUpperCase()}
 					</button>
-					<a download='JSONReshaperdata' href={fileLink} className="border py-1 px-2" onClick={handleDownload}>
+					<a download={`json-reshaper.${format}`} href={fileLink} className="border py-1 px-2" onClick={handleDownload}>
 						Download {format.toUpperCase()}
 					</a>
 				</div>

--- a/src/components/OutputPreview.tsx
+++ b/src/components/OutputPreview.tsx
@@ -20,6 +20,7 @@ interface Props {
 
 export const OutputPreview = ({ columnQueries, filteredJson }: Props) => {
 	const [format, setFormat] = useState<OutputFormat>(OutputFormat.CSV);
+	const [fileLink, setFileLink] = useState<string>('');
 	const getTransformedAsText = useRef<DataTransformerFxn>(() => {
 		throw new Error('Transformer not mounted');
 	});
@@ -49,6 +50,16 @@ export const OutputPreview = ({ columnQueries, filteredJson }: Props) => {
 			});
 	}, []);
 
+	const handleDownload = useCallback(()=>{		
+		const transformedText = getTransformedAsText.current();
+		let type = OutputFormat.CSV;
+		if(format === OutputFormat.TSV)
+			type = OutputFormat.TSV
+		let data = new Blob([transformedText], {type:`text/${type}`});
+		let url = window.URL.createObjectURL(data);
+		setFileLink(url);
+	}, [format])
+
 	return (
 		<section className="flex flex-col min-w-0">
 			<p className="font-bold mb-2">Output Preview</p>
@@ -68,10 +79,13 @@ export const OutputPreview = ({ columnQueries, filteredJson }: Props) => {
 						))}
 					</select>
 				</div>
-				<div className="ml-auto">
+				<div className="ml-auto flex gap-2">
 					<button className="border py-1 px-2" onClick={handleCopyEvent}>
 						Copy as {format.toUpperCase()}
 					</button>
+					<a download='JSONReshaperdata' href={fileLink} className="border py-1 px-2" onClick={handleDownload}>
+						Download {format.toUpperCase()}
+					</a>
 				</div>
 			</div>
 			<div className="bg-white grow p-3 rounded overflow-hidden h-0">


### PR DESCRIPTION
Added a download button as mention in [Issue 7](https://github.com/allejo/json-reshaper/issues/7).
Note: Its working well when the format is selected as CSV, but I am unable to figure out the type for tsv file should use in blob.

## Preview
[Screencast from 2023-08-20 10-19-13.webm](https://github.com/allejo/json-reshaper/assets/55751461/ab54f9ce-0b9b-45bc-9c80-0c3f11013b6a)
